### PR TITLE
enable matplotlib interactive

### DIFF
--- a/01-PythonProgramming/matplotlib-Intro.ipynb
+++ b/01-PythonProgramming/matplotlib-Intro.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
+    "%matplotlib ipympl"
    ]
   },
   {
@@ -1101,7 +1101,25 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
Hello professor Oquendo.

Looking at the matplotlib tutorial it will be great to get interactive plots. This can be possible done by using a different matplotlib backend as [ipympl ](https://matplotlib.org/ipympl/) or [qt](https://www.pythonguis.com/tutorials/plotting-matplotlib/). It is a small enhancement that makes plots more interesting and fun.

Another comment is for the optimization tutorials. In addition to scipy, which is very robust and well-documented, there is another new interesting optimization package called [lmfit-py](https://lmfit.github.io/lmfit-py/), it will be great if you take a look at it.